### PR TITLE
Tweaks to script install instructions

### DIFF
--- a/src/routes/help/install/script.svelte
+++ b/src/routes/help/install/script.svelte
@@ -46,8 +46,8 @@
                 <strong>Save the downloaded script</strong>
                 <br />
                 You can save it anywhere on your computer, though make sure you can keep it there permenantly.
-                The two most common places to save these are in the same folder you installed the plugin,
-                or a cloud-synced folder (like for Dropbox or Google Drive).
+                Two common places to save these are in the same folder you installed the plugin,
+                or in a cloud-synced folder (like for Dropbox or Google Drive).
             </li>
             <li>
                 <strong>Open Finale and open a document</strong>
@@ -57,28 +57,33 @@
             <li>
                 <strong>Open the plugin</strong>
                 <br />
-                For RGP Lua, to to
+                For RGP Lua, go to
                 <code>Plug-ins > Lua > RGP Lua…</code>. For JW Lua, to to
-                <code>Plug-ins > Lua > JW Lua…</code>.
+                <code>Plug-ins > Lua > JW Lua…</code>. (Assuming that when you installed 
+                RGP/JW Lua, you used a folder called <code>Lua</code>.)
             </li>
             <li>
-                <strong>
-                    Go to the manager tab and click on the <code>[menu]</code> plug-in group
-                </strong>
-            </li>
-            <li>
-                <strong>Click "open" next to the Plug-in Groups section</strong>
+                <strong>For RGP Lua</strong>
                 <br />
-                Note that there are two "open" buttons. You want to click the bottom one.
+                Click the <code>Add</code> button and then the <code>Select File…</code>
+                button to add an individual Lua script.
+            </li>
+            <li>
+                <strong>For JW Lua</strong>
+                <br />
+                Go to the manager tab and click on the <code>[menu]</code> plug-in group.
+                Then click "open" next to the Plug-in Groups section. Note that there are
+                two "open" buttons. You want to click the bottom one.
             </li>
             <li>
                 <strong>Find the saved <code>.lua</code> and select it</strong>
                 <br />
-                Click "open", and the file should now be listed under Items in Group.
+                For RGP Lua, click "open" and then "OK". For JW Lua, click "open".
+                You should now see the file listed in the plug-in window.
             </li>
             <li>
                 <strong>Close the plugin</strong>. You may also get a warning that the changes will
-                not be reflected until you restart Finale, you can close this warning.
+                not be reflected until you restart Finale; you can close this warning.
             </li>
             <li>
                 <strong>Restart Finale and view the new script under Plug-ins > Lua</strong>


### PR DESCRIPTION
Minimal edits to script install page to be compatible with both JW and RGP. 

There are other edits in the help docs that I think would be useful, but I'm a little daunted by the layers of the rendering framework. Would it work if I made a list of things that could be updated and then someone more familiar with the workings of the site made the actual changes?