### PR TITLE
Markdown in notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "@sveltejs/adapter-static": "1.0.0-next.13",
         "date-fns": "2.23.0",
         "js-search": "2.0.0",
+        "marked": "^11.1.1",
         "redis": "3.1.2"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ dependencies:
   js-search:
     specifier: 2.0.0
     version: 2.0.0
+  marked:
+    specifier: ^11.1.1
+    version: 11.1.1
   redis:
     specifier: 3.1.2
     version: 3.1.2
@@ -3066,6 +3069,12 @@ packages:
     dependencies:
       sourcemap-codec: 1.4.8
     dev: true
+
+  /marked@11.1.1:
+    resolution: {integrity: sha512-EgxRjgK9axsQuUa/oKMx5DEY8oXpKJfk61rT5iY3aRlgU6QJtUcxU5OAymdhCvWvhYcd9FKmO5eQoX8m9VGJXg==}
+    engines: {node: '>= 18'}
+    hasBin: true
+    dev: false
 
   /marked@2.1.3:
     resolution: {integrity: sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==}

--- a/src/lib/components/script-notes/leaf-inner.svelte
+++ b/src/lib/components/script-notes/leaf-inner.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { marked } from 'marked'
     export let text: string
     $: parts = text.split('  \n')
 </script>
@@ -7,5 +8,5 @@
     {#if index !== 0}
         <br />
     {/if}
-    {part}
+    {@html marked.parseInline(part)}
 {/each}

--- a/src/lib/components/script-notes/script-notes.svelte
+++ b/src/lib/components/script-notes/script-notes.svelte
@@ -6,7 +6,12 @@
 
     type Block =
         | {
-              type: 'p' | 'code'
+              type: 'p'
+              content: string
+              style: string
+          }
+        | {
+              type: 'code'
               content: string
           }
         | {
@@ -17,6 +22,7 @@
     type Content = Block[]
 
     let content: Content = []
+
     $: {
         const lines = notes.split('\n\n')
         content = lines.map((line) => {
@@ -42,9 +48,15 @@
                     }),
                 }
             } else {
+                let classString = ''
+                if (line.startsWith('###')) classString = 'text-lg font-bold'
+                else if (line.startsWith('##')) classString = 'text-xl font-bold'
+                else if (line.startsWith('#')) classString = 'text-2xl font-bold'
+
                 return {
                     type: 'p',
-                    content: line,
+                    content: line.replace(/#+\s*/, ''),
+                    style: classString,
                 }
             }
         })
@@ -54,7 +66,7 @@
 <div class="my-3 flex flex-col space-y-2">
     {#each content as block}
         {#if block.type == 'p'}
-            <p>
+            <p class="{block.style}">
                 <Leaf text="{block.content}" />
             </p>
         {:else if block.type == 'ul'}


### PR DESCRIPTION
@rpatters1 This will get you bold, italic, and headers when displaying the notes for a script. Note that h4-h6 will be styled just like h3; I can add specific styling for these, but I thought it was unlikely that they would be needed.

![image](https://github.com/finale-lua/jw-lua-scripts-docs/assets/5248041/5a7c01e3-7708-4849-b0a7-350c47adcb03)


Tables are more complicated, because of spacing and alignment; I was able to emit the proper HTML, but I wasn't happy with the way things looked. By default, a table will take up the full width of its container (likely larger than needed), and table headers will be center-aligned. I'm not sure how to impose reasonable defaults, and I don't want to get into allowing styling directly in the Markdown.